### PR TITLE
Issue #8: macos/AddressBookPlugin.swift Threading warning, line: 55

### DIFF
--- a/ios/Classes/SwiftAddressbookPlugin.swift
+++ b/ios/Classes/SwiftAddressbookPlugin.swift
@@ -50,7 +50,7 @@ public class SwiftAddressbookPlugin: NSObject, FlutterPlugin {
                 }
                 
                 let fetchRequest = CNContactFetchRequest(keysToFetch: keysToFetch)
-                DispatchQueue.global().sync {
+                DispatchQueue.global().async {
                     
                     // fetch all contacts
                     try? store.enumerateContacts(with: fetchRequest, usingBlock: { (contact, stop) in
@@ -118,9 +118,11 @@ public class SwiftAddressbookPlugin: NSObject, FlutterPlugin {
                         
                         contacts = contacts.adding(contactMap) as NSArray
                     })
+
+                    DispatchQueue.main.async {
+                        result(contacts)
+                    }
                 }
-                
-                result(contacts)
             }
         } else {
             result(nil)

--- a/macos/Classes/AddressbookPlugin.swift
+++ b/macos/Classes/AddressbookPlugin.swift
@@ -49,7 +49,7 @@ public class AddressbookPlugin: NSObject, FlutterPlugin {
                 }
                 
                 let fetchRequest = CNContactFetchRequest(keysToFetch: keysToFetch)
-                DispatchQueue.global().sync {
+                DispatchQueue.global().async {
                     
                     // fetch all contacts
                     try? store.enumerateContacts(with: fetchRequest, usingBlock: { (contact, stop) in
@@ -117,9 +117,11 @@ public class AddressbookPlugin: NSObject, FlutterPlugin {
                         
                         contacts = contacts.adding(contactMap) as NSArray
                     })
+
+                    DispatchQueue.main.async {
+                        result(contacts)
+                    }
                 }
-                
-                result(contacts)
             }
         } else {
             result(nil)


### PR DESCRIPTION
This fixes the following warning:
![image](https://github.com/user-attachments/assets/aec532d8-52f0-4b69-a5d9-a169d6a5d750)

Don't block the main thread with a sync call to the global dispatch queue. Instead invoke the call asynchronously to allow the main thread to continue. The enumerateContacts call is blocking on the global dispatch queue thread. When it is done we can invoke the results back onto the main thread.
